### PR TITLE
remove timeout on chromedriver

### DIFF
--- a/openconnect-pulse-launcher.py
+++ b/openconnect-pulse-launcher.py
@@ -134,9 +134,8 @@ class OpenconnectPulseLauncher:
                 logging.info('Starting browser.')
                 driver = webdriver.Chrome(service=service, options=options)
 
-                wait = WebDriverWait(driver, 60)
                 driver.get(vpn_url)
-                dsid = wait.until(lambda driver: driver.get_cookie('DSID'))
+                dsid = WebDriverWait(driver, float('inf')).until(lambda driver: driver.get_cookie('DSID'))
                 driver.quit()
                 if self.is_dsid_valid(dsid):
                     cookie_file_handle = open(self.cookie_file, 'w')


### PR DESCRIPTION
Previously, the timeout on chromedriver meant that the user only had 60 seconds to login before the window would close on its own.  Now, the window closes only when the user explicitly does so.