### PR TITLE
pass Ctrl-C to openconnect as SIGINT, not SIGTERM

### DIFF
--- a/openconnect-pulse-launcher.py
+++ b/openconnect-pulse-launcher.py
@@ -24,7 +24,7 @@ class OpenconnectPulseLauncher:
     def signal_handler(self, sig, frame):
         subprocess.run(['sudo', 'route', 'del', 'default', 'gw', self.vpn_gateway_ip])
         while 'openconnect' in (i.name() for i in psutil.process_iter()):
-            subprocess.run(['sudo', 'pkill', 'openconnect'])
+            subprocess.run(['sudo', 'pkill', '-SIGINT', 'openconnect'])
         ps = subprocess.Popen(
             ['getent', 'hosts', self.hostname],
             stdout=subprocess.PIPE,


### PR DESCRIPTION
Since `signal_handler` runs when a SIGINT (Ctrl-C) is received, we should probably pass it on to `openconnect` as a SIGINT, not the default SIGTERM.  (Though in practice it seems to have the same effect.)