### PR TITLE
remove cookie saving

### DIFF
--- a/openconnect-pulse-launcher.py
+++ b/openconnect-pulse-launcher.py
@@ -44,16 +44,6 @@ class OpenconnectPulseLauncher:
         self.chrome_profile_dir = os.path.join(xdg_config_home(), 'chromedriver', 'pulsevpn')
         if not os.path.exists(self.chrome_profile_dir):
             os.makedirs(self.chrome_profile_dir)
-        config_dir = os.path.join(xdg_config_home(), 'openconnect-pulsevpn')
-        if not os.path.exists(config_dir):
-            os.makedirs(config_dir)
-
-        self.cookie_file = os.path.join(config_dir, 'cookie.txt')
-        cookie = None
-        if os.path.isfile(self.cookie_file):
-          cookie_file_handle = open(self.cookie_file, 'r')
-          cookie = cookie_file_handle.read()
-          cookie_file_handle.close()
 
         self.vpn_gateway_ip = None
 
@@ -138,11 +128,6 @@ class OpenconnectPulseLauncher:
                 driver.get(vpn_url)
                 dsid = wait.until(lambda driver: driver.get_cookie('DSID'))
                 driver.quit()
-                if self.is_dsid_valid(dsid):
-                    cookie_file_handle = open(self.cookie_file, 'w')
-                    cookie = cookie_file_handle.write(dsid['value'])
-                    cookie_file_handle.close()
-
                 logging.info('DSID cookie: %s', dsid)
 
 def main(argv):


### PR DESCRIPTION
Cookie saving was not actually functional (the value read from the saved file is not actually used), cluttered user file systems, and created a potential security vulnerability (by saving the cookie in plain text).

Since it has downsides and no benefit as currently implemented, this PR removes this code.  Users who want to manually know their cookie can always pass `--debug` to the command.

This PR might be controversial since it looks like it is removing a feature.  However, note that the feature doesn't currently work and is just leaking the DSID cookie in plain text to the file system (a security weakness).  While it does read it back from the file system, it does not actually use it.