### PR TITLE
fix: make sure to get the correct chromium version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -32,6 +32,6 @@ pkgs.stdenv.mkDerivation {
     install -Dm755 ${./openconnect-pulse-launcher.py} $out/bin/openconnect-pulse-launcher
 
     wrapProgram $out/bin/openconnect-pulse-launcher \
-      --suffix PATH : ${runtime-paths}
+      --prefix PATH : ${runtime-paths}
   '';
 }


### PR DESCRIPTION
Without this patch, if a different chromium version was installed in the host, the script failed.

<details>

```
Traceback (most recent call last):
  File "/nix/store/sd381gkmqcx5lhzh6qk9p1k62gdh2rs9-openconnect-pulse-launcher/bin/.openconnect-pulse-launcher-wrapped", line 166, in <module>
    main(sys.argv[1:])
  File "/nix/store/sd381gkmqcx5lhzh6qk9p1k62gdh2rs9-openconnect-pulse-launcher/bin/.openconnect-pulse-launcher-wrapped", line 163, in main
    launcher.connect(vpn_url, chromedriver_path=chromedriver_path, chromium_path=chromium_path, debug=debug, script=script)
  File "/nix/store/sd381gkmqcx5lhzh6qk9p1k62gdh2rs9-openconnect-pulse-launcher/bin/.openconnect-pulse-launcher-wrapped", line 125, in connect
    driver = webdriver.Chrome(service=service, options=options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/rjvnwj4l54in4j54cc703c0xlmz6wjiw-python3-3.12.8-env/lib/python3.12/site-packages/selenium/webdriver/chrome/webdriver.py", line 45, in __init__
    super().__init__(
  File "/nix/store/rjvnwj4l54in4j54cc703c0xlmz6wjiw-python3-3.12.8-env/lib/python3.12/site-packages/selenium/webdriver/chromium/webdriver.py", line 66, in __init__
    super().__init__(command_executor=executor, options=options)
  File "/nix/store/rjvnwj4l54in4j54cc703c0xlmz6wjiw-python3-3.12.8-env/lib/python3.12/site-packages/selenium/webdriver/remote/webdriver.py", line 212, in __init__
    self.start_session(capabilities)
  File "/nix/store/rjvnwj4l54in4j54cc703c0xlmz6wjiw-python3-3.12.8-env/lib/python3.12/site-packages/selenium/webdriver/remote/webdriver.py", line 299, in start_session
    response = self.execute(Command.NEW_SESSION, caps)["value"]
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/rjvnwj4l54in4j54cc703c0xlmz6wjiw-python3-3.12.8-env/lib/python3.12/site-packages/selenium/webdriver/remote/webdriver.py", line 354, in execute
    self.error_handler.check_response(response)
  File "/nix/store/rjvnwj4l54in4j54cc703c0xlmz6wjiw-python3-3.12.8-env/lib/python3.12/site-packages/selenium/webdriver/remote/errorhandler.py", line 229, in check_response
    raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.SessionNotCreatedException: Message: session not created: This version of ChromeDriver only supports Chrome version 132
Current browser version is 134.0.6998.88 with binary path /run/current-system/sw/bin/chromium
Stacktrace:
#0 0x588155643eae base::debug::StackTrace::StackTrace()
#1 0x58815510ee66 Status::Status()
#2 0x58815514b8cc (anonymous namespace)::CheckVersion()
#3 0x58815514a708 (anonymous namespace)::WaitForDevToolsAndCheckVersion()
#4 0x5881551463fa (anonymous namespace)::LaunchDesktopChrome()
#5 0x588155140db0 LaunchChrome()
#6 0x58815518f58c (anonymous namespace)::InitSessionHelper()
#7 0x58815518eba6 ExecuteInitSession()
#8 0x588155181f53 base::internal::Invoker<>::Run()
#9 0x58815514e9cd _ZN12_GLOBAL__N_136ExecuteSessionCommandOnSessionThreadEPKcRKNSt4__Cr12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEERKN4base17RepeatingCallbackIF6StatusP7SessionRKNSB_5Value4DictEPNS2_10unique_ptrISG_NS2_14default_deleteISG_EEEEEEEbbSJ_13scoped_refptrINSB_22SingleThreadTaskRunnerEERKNSC_IFvRKSD_SN_SA_bEEERKNSC_IFvvEEE.00738819ce408aa52811629e05e5035a
#10 0x58815514f7be base::internal::Invoker<>::RunOnce()
#11 0x588155615a11 base::TaskAnnotator::RunTaskImpl()
#12 0x588155618fb1 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl()
#13 0x5881556189d8 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()
#14 0x588155619445 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()
#15 0x588155606652 base::MessagePumpDefault::Run()
#16 0x58815561981a base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run()
#17 0x5881555ef375 base::RunLoop::Run()
#18 0x588155633da8 base::Thread::Run()
#19 0x588155633fc2 base::Thread::ThreadMain()
#20 0x588155642bcc _ZN4base12_GLOBAL__N_110ThreadFuncEPv.a67435033112019129ad5c28ddc47327
#21 0x7362e52a0d02 start_thread
```

</details>
